### PR TITLE
Add azure pipelines setting

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,8 +19,16 @@ steps:
     versioningScheme: 'off'
 
 - task: DotNetCoreCLI@2
+  displayName: Unit Test
   inputs:
     command: 'test'
     projects: '**/*.Tests/*.csproj'
     feedsToUse: 'select'
+    versioningScheme: 'off'
+
+- task: DotNetCoreCLI@2
+  displayName: Packaging
+  inputs:
+    command: 'pack'
+    projects: 'src/**/*.csproj'
     versioningScheme: 'off'


### PR DESCRIPTION
Add azure-pipelines setting for development branch,
because it setting is used to build and unit testing
when merging to development from feature branch or fix branch.

FIX: #7 